### PR TITLE
Update submission rules, hero reel, and more

### DIFF
--- a/components/Footer/LandingFooter.tsx
+++ b/components/Footer/LandingFooter.tsx
@@ -32,9 +32,9 @@ export function LandingFooter() {
               Steam.
             </p>
             <p className="font-fancy max-w-2xl text-sm text-fore-9-light dark:text-fore-5-dark">
-              Decky Loader, CSS Loader, and Audio Loader are not affiliated with Valve Corporation.
-              Steam, the Steam logo, Steam Deck, and the Steam Deck logo are trademarks and/or
-              registered trademarks of Valve Corporation in the U.S. and/or other countries.
+              DeckThemes, Decky Loader, CSS Loader, and Audio Loader are not affiliated with Valve
+              Corporation. Steam, the Steam logo, Steam Deck, and the Steam Deck logo are trademarks
+              and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.
             </p>
           </div>
 

--- a/components/HomePage/HeroReel.tsx
+++ b/components/HomePage/HeroReel.tsx
@@ -15,28 +15,16 @@ export function HeroReel() {
   const [themeData, setThemeData] = useState<ThemeQueryResponse>({ total: 0, items: [] });
   const [loaded, setLoaded] = useState<boolean>(false);
 
-  const rotations = ["rotate-2", "-rotate-2"];
   const featuredThemes = [
-    "f16cf40d-7ccc-4981-95bf-77b28e8d101e",
-    "994360e7-cfca-46d3-9337-80d28ad169ba",
-    "11c33bda-cfff-42e6-9a9a-fbd51e341f5a",
-    "231c969d-b16f-41a0-98a1-cec8aeb557ba",
-    "36342841-4128-4043-9a56-333e2bc5d170",
+    "4ba8fe8b-fbd9-457c-94fc-f3555a8877bf", // Outrun, GrodanBool
+    "54cda487-9697-4eaa-94dc-1a613becdc8d", // Pip-Boy, SuchMeme
+    "f16cf40d-7ccc-4981-95bf-77b28e8d101e", // Obsidian, EMERALD0874
+    "994360e7-cfca-46d3-9337-80d28ad169ba", // Art Hero, Metagawa
+    "11c33bda-cfff-42e6-9a9a-fbd51e341f5a", // Phantom, EMERALD0874
+    "231c969d-b16f-41a0-98a1-cec8aeb557ba", // Tilted Home, TheRensei
+    "36342841-4128-4043-9a56-333e2bc5d170", // RGB Keyboard, Party Wumpus
   ];
   const numHeroCards = featuredThemes.length;
-
-  const randomSeed = useMemo(
-    () =>
-      Array(numHeroCards)
-        .fill("")
-        .map(() => Math.random()),
-    [numHeroCards]
-  );
-
-  const getRandomRotationClass = (index: number) => {
-    const randomIndex = Math.floor(randomSeed[index % numHeroCards] * rotations.length);
-    return rotations[randomIndex];
-  };
 
   useEffect(() => {
     Promise.all(
@@ -68,9 +56,7 @@ export function HeroReel() {
         // ref={index === 0 ? firstCardRef : null}
         href={loaded ? `/themes/view?themeId=${data.id}` : "#"}
         key={index}
-        className={`img-shadow group relative aspect-[16/10] w-[24rem] flex-none rounded-xl border-2 border-borders-base1-light bg-[#27272a] transition dark:border-borders-base1-dark dark:bg-zinc-800 sm:rounded-2xl md:w-[32rem] ${getRandomRotationClass(
-          index
-        )}`}
+        className={`img-shadow group relative aspect-[16/10] w-[24rem] flex-none rounded-xl border-2 border-borders-base1-light bg-[#27272a] transition dark:border-borders-base1-dark dark:bg-zinc-800 sm:rounded-2xl md:w-[32rem]`}
       >
         <span className="absolute bottom-0 left-1/2 z-10 -translate-x-1/2 scale-75 text-center text-lg font-semibold opacity-0 transition-all group-hover:translate-y-10 group-hover:scale-100 group-hover:opacity-100">
           {loaded ? data.displayName : ""}
@@ -92,7 +78,7 @@ export function HeroReel() {
   }
   return (
     <>
-      <div className="relative mt-0 flex h-[24rem] max-w-[calc(100vw-48px)] items-center overflow-hidden md:mt-12 md:h-[30rem]">
+      <div className="relative mt-0 flex h-[24rem] max-w-[calc(100vw-48px)] items-center overflow-hidden md:mt-12">
         <style>
           {`
           @keyframes hero-reel-scroll {

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -97,8 +97,8 @@ export default function Nav() {
                       </NavigationMenu.Link>
                     </li>
                     <ul className="m-0 grid list-none gap-x-[10px] p-[12px] sm:w-[300px] sm:grid-flow-col sm:grid-rows-3">
-                      <ListItem href="https://github.com/beebls/DeckThemes" title="GitHub">
-                        Contribute to DeckThemes and CSSLoader on our GitHub
+                      <ListItem href="https://github.com/DeckThemes" title="GitHub">
+                        Contribute to DeckThemes and our plugins on GitHub
                       </ListItem>
                       {!!process.env.NEXT_PUBLIC_DISCORD_URL && (
                         <ListItem href={process.env.NEXT_PUBLIC_DISCORD_URL} title="Discord">
@@ -150,14 +150,14 @@ export default function Nav() {
                           className={`m-0 grid list-none gap-x-[10px] p-[12px] sm:w-[300px] sm:grid-flow-row sm:grid-cols-1`}
                         >
                           <ListItem title="Profile" href="/users/me">
-                            View Your Profile
+                            View your profile
                           </ListItem>
                           <ListItem title="Upload" href="/submit">
-                            Submit Themes or Audio Packs
+                            Submit themes and audio packs
                           </ListItem>
                           {accountInfo.permissions.includes(Permissions.viewSubs) && (
                             <ListItem title="Submissions" href="/submissions">
-                              View Current Submissions
+                              View submissions awaiting approval
                             </ListItem>
                           )}
                         </ul>

--- a/components/Submit/Step1/Step1.tsx
+++ b/components/Submit/Step1/Step1.tsx
@@ -73,10 +73,10 @@ export function Step1({
               }
             }}
             options={[
-              { value: "css", displayText: "CSSLoader" },
+              { value: "css", displayText: "CSS Loader" },
               {
                 value: "audio",
-                displayText: "AudioLoader",
+                displayText: "Audio Loader",
                 disabled: uploadMethod === "css",
               },
             ]}

--- a/components/Submit/Step3/TosCheckboxes.tsx
+++ b/components/Submit/Step3/TosCheckboxes.tsx
@@ -1,5 +1,6 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { codeBlockClasses } from "../SubmitPageTailwindClasses";
+import { CountdownCircleTimer } from "react-countdown-circle-timer";
 
 export function TosCheckboxes({
   setCheckValue,
@@ -10,12 +11,18 @@ export function TosCheckboxes({
   checkValue: boolean;
   uploadType: "audio" | "css";
 }) {
+  // create a countdown timer that counts down from 30 seconds
+  // if the timer runs out, set a state called "expired" to true
+  const [expired, setExpired] = useState<boolean>(false);
+
   return (
     <>
       <div className="flex flex-col items-center gap-4">
-        <ul className="flex list-disc flex-col items-start gap-2 text-sm">
+        {/* max width of 800px */}
+        <ul className="flex max-w-4xl list-disc flex-col items-start gap-2 text-sm">
           {uploadType === "audio" ? (
             <>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:text-2xl">Ownership</span>
               <li>
                 I am the original author of this pack or have permission from the original author to
                 make this submission.
@@ -24,9 +31,20 @@ export function TosCheckboxes({
                 All copyright of this pack&apos;s contents belong to the listed author or is clearly
                 attributed.
               </li>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:mt-[.5rem] md:text-2xl">
+                Compatibility
+              </span>
               <li>
-                This packs works properly on the latest beta and stable versions of SteamOS,
-                decky-loader and AudioLoader.
+                This packs works properly on the latest beta and stable versions of SteamOS, Decky
+                Loader and Audio Loader.
+              </li>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:mt-[.5rem] md:text-2xl">
+                Content
+              </span>
+              <li>
+                If this pack contains music, it is either music from an operating system or console
+                which is not part of an application like a store, a licensed song with a link to the
+                license in the description, or original music with a notice in the description.
               </li>
               <li>This theme is under 10MB in size and uses the least disk space possible.</li>
               <li>
@@ -42,6 +60,9 @@ export function TosCheckboxes({
             </>
           ) : (
             <>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:text-2xl ">
+                Ownership
+              </span>
               <li>
                 I am the original author of this theme or have permission from the original author
                 to make this submission.
@@ -50,47 +71,75 @@ export function TosCheckboxes({
                 All copyright of this theme&apos;s contents belong to the listed author or is
                 clearly attributed.
               </li>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:mt-[.5rem] md:text-2xl">
+                Compatibility
+              </span>
               <li>
-                This theme&apos;s target has been marked appropriately and only styles said target.
-              </li>
-              <li>
-                This theme works properly on the latest beta and stable versions of SteamOS,
-                decky-loader and CSSLoader.
+                This theme works properly on the latest beta and stable versions of SteamOS, Decky
+                Loader and CSS Loader.
               </li>
               <li>
                 This theme only uses <code className={codeBlockClasses}>*</code> or{" "}
                 <code className={codeBlockClasses}>!important</code> if absolutely necessary.
               </li>
-              <li>This theme is under 10MB in size and uses the least disk space possible.</li>
               <li>
                 This theme&apos;s preview image does not include text unless it is necessary to
                 describe changes that can be made.
-              </li>
-              <li>
-                This theme is safe for work and does not contain any sexual, drug-related, or
-                profane content.
               </li>
               <li>This theme prefixes any CSS variables with a unique identifier.</li>
               <li>
                 This theme does not bundle any other themes with it, and uses dependencies where
                 necessary.
               </li>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:mt-[.5rem] md:text-2xl">
+                Target
+              </span>
+              <li>
+                This theme&apos;s target has been marked appropriately and only styles said target.
+              </li>
               <li>If this theme targets the keyboard, it applies to the default keyboard.</li>
               <li>
                 If this is a system-wide theme that also targets the keyboard, the keyboard theming
-                is toggleable
+                is toggleable.
               </li>
+              <span className="font-fancy w-full text-xl md:ml-[-1rem] md:mt-[.5rem] md:text-2xl">
+                Other
+              </span>
+              <li>
+                This theme is safe for work and does not contain any sexual, drug-related, or
+                profane content.
+              </li>
+              <li>This theme is under 10MB in size and uses the least disk space possible.</li>
             </>
           )}
         </ul>
-        <div className="flex items-center gap-4 text-xl">
-          <span>By checking this box you agree to the above terms: </span>
-          <input
-            type="checkbox"
-            checked={checkValue}
-            onChange={(e) => setCheckValue(e.target.checked)}
-            className="h-5 w-5 rounded-3xl ring-offset-2 ring-offset-cardLight hover:ring-2 dark:ring-offset-cardDark"
-          />
+        <div className="flex items-center gap-4 text-xl md:mt-[1rem]">
+          <span>By checking this box you agree to the above terms. </span>
+          {!expired ? (
+            <CountdownCircleTimer
+              // only play if parent of the parent has class "visible"
+              isPlaying={document.querySelector(".disable-timer") === null}
+              duration={10}
+              onComplete={() => setExpired(true)}
+              size={40}
+              strokeWidth={4}
+              colors={"#2563eb"}
+            >
+              {({ remainingTime }) => remainingTime}
+            </CountdownCircleTimer>
+          ) : (
+            <input
+              type="checkbox"
+              disabled={!expired}
+              checked={checkValue}
+              onChange={(e) => setCheckValue(e.target.checked)}
+              className="h-5 w-5 rounded-3xl ring-offset-2 ring-offset-cardLight hover:ring-2 dark:ring-offset-cardDark"
+            />
+          )}
+        </div>
+        <div className="flex max-w-md items-center gap-4 text-center text-xs">
+          Repeat violations of our terms of service and submission terms may result in your account
+          being suspended.
         </div>
       </div>
     </>

--- a/components/Submit/SubmitStepsCarousel.tsx
+++ b/components/Submit/SubmitStepsCarousel.tsx
@@ -101,7 +101,7 @@ export function SubmitStepsCarousel({
           <span className="font-fancy w-full pb-4 text-center text-2xl font-semibold md:text-4xl">
             {stepTitles[currentStep - 1]}
           </span>
-          <div className="w-full py-8">
+          <div className="w-full">
             <div className={currentStep !== 1 ? "hidden" : "w-full"}>
               <Step1
                 {...{
@@ -133,7 +133,7 @@ export function SubmitStepsCarousel({
                 </div>
               </div>
             )}
-            <div className={currentStep !== totalSteps ? "hidden" : "w-full"}>
+            <div className={currentStep !== totalSteps ? "disable-timer hidden" : "w-full"}>
               <div className="flex w-full flex-col items-center justify-center gap-4">
                 <TosCheckboxes
                   checkValue={hasAcceptedTos}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "next-themes": "^0.2.1",
         "react": "18.2.0",
         "react-color-extractor": "^1.1.2",
+        "react-countdown-circle-timer": "^3.2.1",
         "react-debounce-input": "^3.3.0",
         "react-dom": "18.2.0",
         "react-dropdown": "^1.11.0",
@@ -4363,6 +4364,14 @@
         "react": "^16.3.2"
       }
     },
+    "node_modules/react-countdown-circle-timer": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-countdown-circle-timer/-/react-countdown-circle-timer-3.2.1.tgz",
+      "integrity": "sha512-yBAy/9ILXOiFbLBM+3jS72TW5LeRcH8wkRC9NNqMpUkCXkGjSnaeRbJMsR9lsYF0oVXjSDbJaRbCuVMT+9HnKA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-debounce-input": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.3.0.tgz",
@@ -8147,6 +8156,11 @@
       "requires": {
         "node-vibrant": "^3.0.0"
       }
+    },
+    "react-countdown-circle-timer": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-countdown-circle-timer/-/react-countdown-circle-timer-3.2.1.tgz",
+      "integrity": "sha512-yBAy/9ILXOiFbLBM+3jS72TW5LeRcH8wkRC9NNqMpUkCXkGjSnaeRbJMsR9lsYF0oVXjSDbJaRbCuVMT+9HnKA=="
     },
     "react-debounce-input": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next-themes": "^0.2.1",
     "react": "18.2.0",
     "react-color-extractor": "^1.1.2",
+    "react-countdown-circle-timer": "^3.2.1",
     "react-debounce-input": "^3.3.0",
     "react-dom": "18.2.0",
     "react-dropdown": "^1.11.0",

--- a/pages/download/deck.tsx
+++ b/pages/download/deck.tsx
@@ -9,14 +9,14 @@ export default function DeckDownload() {
         {/* Headline */}
         <h1 className="mx-auto max-w-4xl text-center text-5xl font-extrabold tracking-tight sm:text-6xl">
           <span className="">
-            CSSLoader <br className="block sm:hidden" />
+            CSS Loader <br className="block sm:hidden" />
           </span>{" "}
           for Steam Deck
         </h1>
 
         {/* Blurb */}
         <p className="font-fancy mx-auto mt-6 max-w-2xl text-center text-sm font-medium leading-6 text-fore-10-light dark:text-fore-10-dark sm:text-lg">
-          Steam Deck is supported through Decky Loader. You can also install CSSLoader on your{" "}
+          Steam Deck is supported through Decky Loader. You can also install CSS Loader on your{" "}
           <Link className="text-brandBlue hover:underline" href={"/download/windows"}>
             Windows PC
           </Link>
@@ -42,7 +42,7 @@ export default function DeckDownload() {
         </InstallSection>
 
         <InstallSection>
-          <InstallSection.Header>Install CSSLoader</InstallSection.Header>
+          <InstallSection.Header>Install CSS Loader</InstallSection.Header>
 
           <InstallSection.Content>
             <ol className="flex w-full list-decimal flex-col gap-4">
@@ -75,7 +75,7 @@ export default function DeckDownload() {
         </InstallSection>
 
         <InstallSection>
-          <InstallSection.Header>Using CSSLoader</InstallSection.Header>
+          <InstallSection.Header>Using CSS Loader</InstallSection.Header>
 
           <InstallSection.Content>
             <div className="flex flex-row flex-wrap items-center">

--- a/pages/download/windows.tsx
+++ b/pages/download/windows.tsx
@@ -10,20 +10,20 @@ export default function WindowsDownload() {
         {/* Headline */}
         <h1 className="mx-auto max-w-4xl text-center text-5xl font-extrabold tracking-tight sm:text-6xl">
           <span className="">
-            CSSLoader <br className="block sm:hidden" />
+            CSS Loader <br className="block sm:hidden" />
           </span>{" "}
           for Windows
         </h1>
         {/* Blurb */}
         <p className="font-fancy mx-auto mt-6 max-w-2xl text-center text-sm font-medium leading-6 text-fore-10-light dark:text-fore-10-dark sm:text-lg">
-          CSSLoader on Windows uses a native backend with a standalone frontend. You also install
-          CSSLoader on your{" "}
+          CSS Loader on Windows uses a native backend with a standalone frontend. You also install
+          CSS Loader on your{" "}
           <Link className="text-brandBlue hover:underline" href={"/download/deck"}>
             Steam Deck
           </Link>
         </p>
         <InstallSection>
-          <InstallSection.Header>Install CSSLoader Desktop</InstallSection.Header>
+          <InstallSection.Header>Install CSS Loader Desktop</InstallSection.Header>
 
           <InstallSection.Content>
             <ol className="flex w-full list-decimal flex-col gap-4">
@@ -45,7 +45,7 @@ export default function WindowsDownload() {
               <li>
                 <div className="flex flex-row items-center">
                   Run the installer and follow the on-screen instructions. Note that if this is your
-                  first time using CSSLoader Desktop, you'll be prompted to install the backend on
+                  first time using CSS Loader Desktop, you'll be prompted to install the backend on
                   launch.
                 </div>
               </li>
@@ -54,7 +54,7 @@ export default function WindowsDownload() {
                   Your antivirus may flag the backend executable, if so, please allow it to run.{" "}
                   <a
                     className="text-brandBlue hover:underline"
-                    href="https://github.com/suchmememanyskill/SDH-CssLoader"
+                    href="https://github.com/DeckThemes/SDH-CssLoader"
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -63,7 +63,7 @@ export default function WindowsDownload() {
                   and{" "}
                   <a
                     className="text-brandBlue hover:underline"
-                    href="https://github.com/suchmememanyskill/SDH-CssLoader/releases"
+                    href="https://github.com/DeckThemes/SDH-CssLoader/releases"
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -89,7 +89,7 @@ export default function WindowsDownload() {
                     <li>Select 'For developers'</li>
                     <li>Enable 'Developer Mode'</li>
                     <li>
-                      If CSSLoader's backend is already installed, reboot your machine for this to
+                      If CSS Loader's backend is already installed, reboot your machine for this to
                       take effect.
                     </li>
                     <li>Developer Mode may be disabled after one reboot</li>
@@ -100,7 +100,7 @@ export default function WindowsDownload() {
           </InstallSection.Content>
         </InstallSection>
         <InstallSection>
-          <InstallSection.Header>Using CSSLoader Desktop</InstallSection.Header>
+          <InstallSection.Header>Using CSS Loader Desktop</InstallSection.Header>
 
           <InstallSection.Content>
             <ul className="flex w-full list-disc flex-col gap-4">
@@ -127,7 +127,7 @@ export default function WindowsDownload() {
               <li>
                 <div>
                   <b>Settings</b> contains an input field for your DeckThemes login token, as well
-                  as additional settings for CSSLoader.
+                  as additional settings for CSS Loader.
                 </div>
               </li>
             </ul>
@@ -141,7 +141,7 @@ export default function WindowsDownload() {
             target="_blank"
             rel="noreferrer"
           >
-            CSSLoader Desktop's readme
+            CSS Loader Desktop's readme
           </a>
         </span>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ export default function Home() {
         <meta name="title" content="DeckThemes" />
         <meta
           name="description"
-          content="CSSLoader and AudioLoader themes for Steam Deck and Desktop Steam"
+          content="CSS Loader and Audio Loader themes for Steam Deck and Desktop Steam"
         />
 
         <meta property="og:type" content="website" />
@@ -22,7 +22,7 @@ export default function Home() {
         <meta property="og:title" content="DeckThemes" />
         <meta
           property="og:description"
-          content="CSSLoader and AudioLoader themes for Steam Deck and Desktop Steam"
+          content="CSS Loader and Audio Loader themes for Steam Deck and Desktop Steam"
         />
 
         <meta property="twitter:card" content="summary_large_image" />
@@ -30,7 +30,7 @@ export default function Home() {
         <meta property="twitter:title" content="DeckThemes" />
         <meta
           property="twitter:description"
-          content="CSSLoader and AudioLoader themes for Steam Deck and Desktop Steam"
+          content="CSS Loader and Audio Loader themes for Steam Deck and Desktop Steam"
         />
       </Head>
 
@@ -70,20 +70,20 @@ export default function Home() {
           <HighlightCarousel
             options={[
               {
-                title: "BPM CSS Themes",
+                title: "Big Picture Themes",
                 searchFilter: "BPM-CSS",
                 hrefLink: "/themes?type=BPM-CSS",
                 buttonText: "BPM",
               },
               {
-                title: "Desktop CSS Themes",
+                title: "Desktop Themes",
                 searchFilter: "DESKTOP-CSS",
                 hrefLink: "/themes?type=DESKTOP-CSS",
                 buttonText: "Desktop",
               },
               // This has a trailing ? because the link filler only knows to add "&order="
               {
-                title: "AudioLoader Packs",
+                title: "Audio Packs",
                 searchFilter: "AUDIO",
                 hrefLink: "/packs?",
                 buttonText: "Audio",

--- a/pages/packs/index.tsx
+++ b/pages/packs/index.tsx
@@ -29,9 +29,6 @@ export default function Packs() {
       <Head>
         <title>DeckThemes | Audio Loader Packs</title>
       </Head>
-      <div className="mb-12 flex flex-col items-center">
-        <h1 className="pt-4 text-3xl font-extrabold md:text-5xl lg:pt-24">Audio Packs</h1>
-      </div>
       {defaults !== undefined && (
         <ThemeCategoryDisplay
           {...defaults}

--- a/pages/packs/index.tsx
+++ b/pages/packs/index.tsx
@@ -27,7 +27,7 @@ export default function Packs() {
   return (
     <>
       <Head>
-        <title>DeckThemes | AudioLoader Packs</title>
+        <title>DeckThemes | Audio Loader Packs</title>
       </Head>
       <div className="mb-12 flex flex-col items-center">
         <h1 className="pt-4 text-3xl font-extrabold md:text-5xl lg:pt-24">Audio Packs</h1>

--- a/pages/themes/index.tsx
+++ b/pages/themes/index.tsx
@@ -33,7 +33,7 @@ export default function Themes() {
   return (
     <>
       <Head>
-        <title>DeckThemes | CSSLoader Themes</title>
+        <title>DeckThemes | CSS Loader Themes</title>
       </Head>
       {/* <div className="mb-12 flex flex-col items-center">
         <h1 className="pt-4 text-3xl font-extrabold md:text-5xl lg:pt-24">CSS Themes</h1>

--- a/pages/tos.tsx
+++ b/pages/tos.tsx
@@ -90,7 +90,7 @@ export default function ToS() {
           </p>
           <h2>
             <strong>
-              Requirements for audio assets <em>(AudioLoader)</em>:
+              Requirements for audio assets <em>(Audio Loader)</em>:
             </strong>
           </h2>
           <ul>
@@ -110,12 +110,12 @@ export default function ToS() {
             <li>Make sure that the asset have been properly tested before being submited.</li>
             <li>
               Make sure it work properly on the lastest beta and stable versions of SteamOS, Decky
-              Loader, and AudioLoader
+              Loader, and Audio Loader
             </li>
           </ul>
           <h2>
             <strong>
-              Requirements for visual assets <em>(CSSLoader &amp; AudioLoader)</em>:
+              Requirements for visual assets <em>(CSS Loader &amp; Audio Loader)</em>:
             </strong>
           </h2>
           <ul>


### PR DESCRIPTION
# General changes
- Add "DeckThemes" to the list of copyrights not associated with Valve Corporation
- Add Outrun by GordanBool and Pip-Boy by SuchMeme to the hero reel because of their major transformation of the Steam UI
- Replace "CSSLoader" and "AudioLoader" with "CSS Loader" and "Audio Loader"
- Change profile dropdown options to use sentence capitalization for their descriptions
- Remove Audio Packs header from the Audio Packs page to match the CSS Themes page

# Submission
- Separate submission terms into different categories for easier reading
- Update the Audio Loader copyright statement
- Add a countdown timer that replaces the checkbox until complete to encourage reading
- Add a warning about repeat terms of service violations to discourage spam
![image](https://github.com/beebls/DeckThemes/assets/11338953/7edf39ea-2ffa-4773-8817-8a68db9d02bf)

# Hero reel
- Remove card tilt from the hero reel as it's a bit distracting
- Remove the margin from the top of the hero reel to show more of the card images without scrolling
<img width="1505" alt="image" src="https://github.com/beebls/DeckThemes/assets/11338953/4255ab59-e770-467e-8c84-db23df3ad57e">

# Featured themes and packs
- Change "BPM CSS Themes" to "Big Picture Themes"
- Change "Desktop Themes" to "Desktop Themes"
- Change "AudioLoader Packs" to "Audio Packs"