### PR TITLE
Remove `null` images in submission

### DIFF
--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -22,7 +22,7 @@ export default function Submit() {
     metaInfo: MetaInfo
   ) {
     const formattedMeta = {
-      imageBlobs: metaInfo.imageBlobs,
+      imageBlobs: metaInfo.imageBlobs.filter(Boolean),
       description: metaInfo.description || null,
       target: metaInfo.target !== "None" ? metaInfo.target : null,
     };


### PR DESCRIPTION
for some reason if you cancel an already uploaded blob, it keeps a `null` in the array, this fixes that.